### PR TITLE
added sharedflows mmv1 with error

### DIFF
--- a/mmv1/products/apigee/api.yaml
+++ b/mmv1/products/apigee/api.yaml
@@ -659,4 +659,87 @@ objects:
       guides:
         'Provisioning NAT IPs':
           'https://cloud.google.com/apigee/docs/api-platform/security/nat-provisioning'
-      api: 'https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.instances.natAddresses'
+      api: 'https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.instances.natAddresses'      
+  - !ruby/object:Api::Resource
+    name: 'SharedFlow'
+    base_url: 'organizations/{{org_id}}/sharedflows/{{name}}'
+    create_url: 'organizations/{{org_id}}/sharedflows?name={{name}}&action=import'
+    delete_url: 'organizations/{{org_id}}/sharedflows/{{name}}'
+    self_link: 'organizations/{{org_id}}/sharedflows/{{name}}'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+        path: 'name'
+        base_url: '{{op_id}}'
+        wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'response'
+        resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
+    input: true
+    description: |
+      You can combine policies and resources into a shared flow that you can consume from multiple API proxies, and even from other shared flows. Although it's like a proxy, a shared flow has no endpoint. It can be used only from an API proxy or shared flow that's in the same organization as the shared flow itself.
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'orgId'
+        description: |
+          The Apigee Organization associated with the Apigee instance,
+          in the format `organizations/{{org_name}}`.
+        required: true
+        input: true
+        url_param_only: true
+      # - !ruby/object:Api::Type::String
+      #   name: 'sharedFlowName'
+      #   description: |
+      #     ID of the shared flow.
+      #   required: true
+      #   input: true
+      #   url_param_only: true
+    properties:
+    - !ruby/object:Api::Type::NestedObject
+          name: 'metaData'
+          description: |
+            Metadata describing the shared flow.
+          output: true
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'createdAt'
+              description: |
+                Time at which the API proxy was created, in milliseconds since epoch.
+            - !ruby/object:Api::Type::String
+              name: 'lastModifiedAt'
+              description: |
+                Time at which the API proxy was most recently modified, in milliseconds since epoch.
+            - !ruby/object:Api::Type::String
+              name: 'subType'
+              description: |
+                The type of entity described
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          The ID of the shared flow.
+        required: true
+      - !ruby/object:Api::Type::Array
+        name: 'revision'
+        description: |
+          A list of revisions of this shared flow.
+        output: true
+        required: true
+        item_type: Api::Type::String
+      - !ruby/object:Api::Type::String
+        name: 'latestRevisionId'
+        description: |
+          The id of the most recently created revision for this shared flow.
+        output: true
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Sharedflows':
+          'https://cloud.google.com/apigee/docs/resources'
+      api: 'https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.sharedflows'

--- a/mmv1/products/apigee/terraform.yaml
+++ b/mmv1/products/apigee/terraform.yaml
@@ -327,6 +327,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       delete_minutes: 30
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/apigee_nat_address.go.erb
+  SharedFlow: !ruby/object:Overrides::Terraform::ResourceOverride
+    autogen_async: true
+    # import_format: ["{{org_id}}/sharedflows/{{name}}", "{{org_id}}/{{name}}"]
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.


### PR DESCRIPTION
DO NOT MERGE, this PR is created for debugging only.

Error Message when running
```
make terraform VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google" PRODUCT=apigee RESOURCE=SharedFlow
```

```
I, [2022-12-02T05:08:13.444383 #2450996]  INFO -- : products/certificatemanager: Compiling provider config
I, [2022-12-02T05:08:13.451412 #2450996]  INFO -- : products/certificatemanager: Not specified, skipping generation
I, [2022-12-02T05:08:13.543063 #2450996]  INFO -- : products/mlengine: Compiling provider config
I, [2022-12-02T05:08:13.548580 #2450996]  INFO -- : products/mlengine: Not specified, skipping generation
bundler: failed to load command: compiler (compiler)
Psych::SyntaxError: (<unknown>): did not find expected key while parsing a block mapping at line 664 column 5
  /usr/local/google/home/xrc/.asdf/installs/ruby/2.6.0/lib/ruby/2.6.0/psych.rb:456:in `parse'
  /usr/local/google/home/xrc/.asdf/installs/ruby/2.6.0/lib/ruby/2.6.0/psych.rb:456:in `parse_stream'
  /usr/local/google/home/xrc/.asdf/installs/ruby/2.6.0/lib/ruby/2.6.0/psych.rb:390:in `parse'
  /usr/local/google/home/xrc/.asdf/installs/ruby/2.6.0/lib/ruby/2.6.0/psych.rb:349:in `safe_load'
  /usr/local/google/home/xrc/repo/TPG/magic-modules-forked/mmv1/google/yaml_validator.rb:25:in `parse'
  /usr/local/google/home/xrc/repo/TPG/magic-modules-forked/mmv1/api/compiler.rb:34:in `run'
  compiler:176:in `block in <top (required)>'
  compiler:143:in `each'
  compiler:143:in `<top (required)>'
make[1]: *** [GNUmakefile:62: mmv1] Error 1
make[1]: Leaving directory '/usr/local/google/home/xrc/repo/TPG/magic-modules-forked'
make: *** [GNUmakefile:58: terraform] Error 2
```

`line 664 column 5` is exactly where the SharedFlow name is defined in `api.yaml`

Not sure why it's complaining about the new Resource Definition. Thank you!